### PR TITLE
Added script for running ngrok server, feat #10

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .DS_Store
 target
 .idea
+ngrok

--- a/README.md
+++ b/README.md
@@ -1,2 +1,13 @@
 # SE-Gorup10-CI
+
 CI server implementation
+
+## How to run
+
+For first time users of the server, run the shell script with a port number and ngrok auth token:
+
+    ./run_ngrok.sh PORT_NUMBER AUTH_TOKEN
+
+After running the program for the first time, the shell script can be called subsequent times with only the port number:
+
+    ./run_ngrok.sh PORT_NUMBER

--- a/run_ngrok.sh
+++ b/run_ngrok.sh
@@ -1,0 +1,56 @@
+#!/bin/bash
+
+
+
+run_mvn_and_ngrok() {
+	# Run maven project and start ngrok tunnel
+        # Don't display maven status but ngrok window
+        mvn exec:java -D"exec.mainClass"="com.group10.CI.ContinuousIntegrationServer" -Dexec.args="$1" &> /dev/null &
+        bg_pid=$!
+        $PWD/ngrok http $1
+        kill "$bg_pid"
+}
+
+
+# Needs a port number to run
+if [ $# -eq 2 ]; then
+	PORT_NUMBER=$1
+	AUTH_TOKEN=$2
+
+	# Downloads ngrok is not detected, downloads it
+	if [ ! -f "ngrok" ]; then
+		echo "--- ngrok not detected ---"
+		echo "Downloading ngrok..."
+		curl  -LO --tlsv1 "https://bin.equinox.io/c/4VmDzA7iaHb/ngrok-stable-linux-amd64.zip"   && \
+		unzip ngrok-stable-linux-amd64.zip                                											&& \
+		rm ngrok-stable-linux-amd64.zip
+	fi
+	
+	# Configure ngrok with AUTH_TOKEN
+	$PWD/ngrok authtoken $2
+
+	# Run mvn project and ngrok tunnel
+	run_mvn_and_ngrok $1 
+
+elif [ $# -eq 1 ]; then
+	PORT_NUMBER=$1
+
+	# Expects that ngrok is already downloaded and auth
+	if [ ! -f "$HOME/.ngrok2/ngrok.yml" ]; then
+		echo "ngrok is not configured yet"
+		echo ""
+		echo "=============================================="
+		echo ""
+		echo "Add AUTH_TOKEN as a parameter to the call"
+		echo ""
+		echo '		./run_ngrok.sh PORT_NUMBER AUTH_TOKEN'
+		echo ""
+		exit
+	fi
+
+	# Run mvn project and ngrok tunnel
+	run_mvn_and_ngrok $1
+
+else
+	echo "Argument missing: You need to provide port to runt ngrok server"
+fi


### PR DESCRIPTION
This PR adds a shell script which handles setup, running the maven project and configuring the ngrok tunnel. 

By providing different parameters to the shell script, it either configures ngrok (downloading if not downloaded) with auth token then runs the tunnel and server for provided port number or it just does the second part with running the tunnel and server.

Info on how to run the shell script is added in the [README.md](https://github.com/ludwigjo/SE-Gorup10-CI/blob/issue/10/README.md)