### PR TITLE
Implements CompilerHandler and unit tests.

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -7,7 +7,7 @@
       </list>
     </option>
   </component>
-  <component name="ProjectRootManager" version="2" project-jdk-name="corretto-11" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_11" default="true" project-jdk-name="corretto-11" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/out" />
   </component>
 </project>

--- a/src/main/java/com/group10/CI/CompileHandler.java
+++ b/src/main/java/com/group10/CI/CompileHandler.java
@@ -1,0 +1,133 @@
+package com.group10.CI;
+
+import java.io.*;
+
+/**
+ * Class responsible for compiling a commit.
+ * */
+public class CompileHandler {
+
+    private final String[] COMPILE_COMMAND = new String[]{"mvn", "compile"};
+    private String commitHash;
+    private Status status;
+    private String compilationInformation;
+    private String repoPath;
+
+    /**
+     * Default constructor.
+     * @param commitHash    the hash of the commit that is being compiled.
+     * @param repoPath      the path to the cloned repo with the commit to be compiled.
+     * */
+    public CompileHandler(String commitHash, String repoPath){
+        this.commitHash = commitHash;
+        this.repoPath = repoPath;
+    }
+
+    /**
+     * Empty constructor
+     * */
+    public  CompileHandler() { }
+
+    /**
+     * Method for compiling the commit.
+     * Runs mvn compile on the commit,
+     *      if the commit compiles without errors the method sets the status to SUCCESS,
+     *      if the compilation failed the status is set to FAILURE,
+     *      if the method is unable to complete the compilation for some reason, the status is set to ERROR.
+     * If the compilation is a success or failure, the compilationInformation is set,
+     * if an error occurred it is null. The status can be retrieved with the getStatus() method
+     * and the compilationInformation can be retrieved with getCompilationInformation().
+     * */
+    public void compile() throws IOException, InterruptedException {
+        setStatus(Status.PENDING);
+
+        File directory = new File(this.repoPath);
+        ProcessBuilder processBuilder = new ProcessBuilder(COMPILE_COMMAND);
+        processBuilder.directory(directory);
+
+        Process process;
+        try {
+            System.out.println("Compilation started ...");
+            process = processBuilder.start();
+            process.waitFor();
+
+            if (process.exitValue() == 0) setStatus(Status.SUCCESS);
+            else setStatus(Status.FAILURE);
+
+            setCompilationInformation(convertInputStreamToString(process.getInputStream()));
+        } catch (IOException | InterruptedException e) {
+            System.out.println("\n ---- ERROR ---- \n" + e.getMessage());
+            setStatus(Status.ERROR);
+            setCompilationInformation(null);
+        }
+        System.out.println("Compilation finished with status: " + getStatus());
+    }
+
+
+    /**
+     * Utility method.
+     * Converts an InputStream to a String. Each line in the InputStream is
+     * on a new line in the String. Sets the status to ERROR if unable to
+     * convert the InputStream to a String.
+     *
+     * @param is    the InputStream
+     * @return      a String of the converted InputStream
+     * */
+    private String convertInputStreamToString(InputStream is) throws IOException {
+        StringBuilder stringBuilder = new StringBuilder();
+
+        try {
+            BufferedReader reader = new BufferedReader(new InputStreamReader(is));
+
+            String line;
+            while ((line = reader.readLine()) != null) {
+                stringBuilder.append(line);
+                stringBuilder.append("\n");
+            }
+            stringBuilder.setLength(stringBuilder.length() - 1);    // remove last /n
+        } catch (IOException e) {
+            System.out.println("\n ---- ERROR ---- \n" + e.getMessage());
+            setStatus(Status.ERROR);
+            return null;
+        }
+
+        return stringBuilder.toString();
+    }
+
+    /**
+     * Sets the status
+     * @param s     the status
+     * */
+    private void setStatus(Status s){
+        this.status = s;
+    }
+
+    /**
+     * Sets the information about the compilation
+     * @param s     the information
+     * */
+    private void setCompilationInformation(String s)  {
+        this.compilationInformation = s;
+    }
+
+    /**
+     * Gets the status of the compilation
+     * */
+    public Status getStatus(){
+        return this.status;
+    }
+
+    /**
+     * Gets the information of the compilation
+     * */
+    public String getCompilationInformation(){
+        return this.compilationInformation;
+    }
+
+    /**
+     * Gets the hash of the commit that is compiled
+     * */
+    public String getCommitHash(){
+        return this.commitHash;
+    }
+}

--- a/src/main/java/com/group10/CI/Status.java
+++ b/src/main/java/com/group10/CI/Status.java
@@ -1,0 +1,16 @@
+package com.group10.CI;
+
+/**
+ * The different statuses that a job (compilation, test) can have. A job can only have one status at a time.
+ *
+ * PENDING is for job not yet started
+ * SUCCESS is for a job that is successfully completed, without failure (e.g. all test pass)
+ * FAILURE is for a job that is successfully completed, but with failures (e.g. all test are run, but not all pass)
+ * ERROR is for a job that was unable to be completed (used for exceptions)
+ * */
+public enum Status {
+    PENDING,
+    SUCCESS,
+    FAILURE,
+    ERROR
+}

--- a/src/test/java/com/group10/CI/CompileHandlerTest.java
+++ b/src/test/java/com/group10/CI/CompileHandlerTest.java
@@ -1,0 +1,74 @@
+package com.group10.CI;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.File;
+import java.io.InputStream;
+import java.lang.reflect.Method;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * Test for the CompileHandler class
+ * Tests for setters and getters are omitted since they are
+ * only responsible for setting and getting, no additional
+ * operations are made.
+ * */
+public class CompileHandlerTest {
+
+    /**
+     * Test if able to compile the project.
+     * Uses GitHandler to clone this project which is stored in a temp directory.
+     * The directory is removed on tear down. Asserts that status is set to SUCCESS,
+     * and that the compilation information contains BUILD SUCCESS (always outputted
+     * when using mvn compile and the build is successful).
+     */
+    @Test
+    @DisplayName("Compile success")
+    public void testCompileSuccess() throws Exception {
+        // set up
+        String mockCommitHash = "9e580b9635fae304a09e6e0dd401910b377a7e51";
+        GitHandler gitHandler = new GitHandler("https://github.com/ludwigjo/SE-Gorup10-CI", "main");
+        CompileHandler ch = new CompileHandler(mockCommitHash, gitHandler.getRepoPath());
+
+        // action
+        ch.compile();
+
+        // assert
+        assertEquals(true, ch.getCompilationInformation().contains("BUILD SUCCESS"));
+        assertEquals(Status.SUCCESS, ch.getStatus(), "Status expected to be SUCCESS if successful compile.");
+
+        // tear down
+        gitHandler.deleteClonedRepo(new File("temp"));
+    }
+
+    /**
+     * Test if able to convert InputStream to String.
+     * The test is constructed by converting a String to an InputStream
+     * via the ByteArrayInputStream class. The using the convertInputStreamToString
+     * to convert it back to a String. If that String is the same as the initial string
+     * the test will pass.
+     *
+     * Since the method is private the Method class is used.
+     * */
+    @Test
+    @DisplayName("Convert from InputStream to String.")
+    public void testConvertInputStreamToString() throws Exception {
+        // set up
+        String initialString = "This is converted to an\n InputStream";
+        InputStream is = new ByteArrayInputStream(initialString.getBytes());
+
+        // action
+        Method method = CompileHandler.class.getDeclaredMethod("convertInputStreamToString", InputStream.class);
+        method.setAccessible(true);
+        String result = (String) method.invoke(new CompileHandler(), is);
+
+        // assert
+        assertEquals(initialString, result, "Initial string and result should be equal");
+    }
+
+}

--- a/src/test/java/com/group10/CI/CompileHandlerTest.java
+++ b/src/test/java/com/group10/CI/CompileHandlerTest.java
@@ -22,10 +22,13 @@ public class CompileHandlerTest {
 
     /**
      * Test if able to compile the project.
+     *
      * Uses GitHandler to clone this project which is stored in a temp directory.
-     * The directory is removed on tear down. Asserts that status is set to SUCCESS,
-     * and that the compilation information contains BUILD SUCCESS (always outputted
-     * when using mvn compile and the build is successful).
+     * The directory is removed on tear down.
+     *
+     * Asserts that status is set to SUCCESS,and that the compilation information
+     * contains BUILD SUCCESS (always outputted when using mvn compile and the
+     * build is successful).
      */
     @Test
     @DisplayName("Compile success")
@@ -45,6 +48,38 @@ public class CompileHandlerTest {
         // tear down
         gitHandler.deleteClonedRepo(new File("temp"));
     }
+
+
+    /**
+     * Test compiling the branch test/build-fail, which contains code with syntax error, thus
+     * the build should not be successful.
+     *
+     * It uses GitHandler to clone this project which is stored in a temp directory.
+     * The directory is removed on tear down.
+     *
+     * Asserts that status is set to FAILURE,
+     * and that the compilation information contains BUILD FAILURE (always outputted
+     * when using mvn compile and the build is unsuccessful).
+     */
+    @Test
+    @DisplayName("Compile failure")
+    public void testCompileFailure() throws Exception {
+        // set up
+        String mockCommitHash = "9e580b9635fae304a09e6e0dd401910b377a7e51";
+        GitHandler gitHandler = new GitHandler("https://github.com/ludwigjo/SE-Gorup10-CI", "test/build-fail");
+        CompileHandler ch = new CompileHandler(mockCommitHash, gitHandler.getRepoPath());
+
+        // action
+        ch.compile();
+
+        // assert
+        assertEquals(true, ch.getCompilationInformation().contains("BUILD FAILURE"));
+        assertEquals(Status.FAILURE, ch.getStatus(), "Status expected to be FAILURE if unsuccessful compile.");
+
+        // tear down
+        gitHandler.deleteClonedRepo(new File("temp"));
+    }
+    
 
     /**
      * Test if able to convert InputStream to String.
@@ -70,5 +105,4 @@ public class CompileHandlerTest {
         // assert
         assertEquals(initialString, result, "Initial string and result should be equal");
     }
-
 }


### PR DESCRIPTION
Fixes #4 
Implements CompilerHandler, corresponding unit test and an enum Status for possible statuses (pending, success, failure, error) during the compilation process. The Status enum can be reused in other classes.

The CompilationHandlerTest is currently missing a unit test on a project that will _not compile_; however, I am uncertain on how to create such a test. Any input is appreciated. 