### PR TITLE
Add Scripts for Deployment of the App on Remote Linux Server

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+# Deploy the app in current git branch to the port $1
+
+if [ $# -eq 1 ]; then
+        PORT_NUMBER=$1
+
+        # compile the app from current branch
+        mvn compile
+
+        # deploy app to the port $1
+        nohup mvn exec:java -D"exec.mainClass"="com.group10.CI.ContinuousIntegrationServer" -Dexec.args="$1" &> /dev/null &
+
+else
+        echo "Argument missing: You need to provide port to runt ngrok server"
+fi

--- a/scripts/pull_and_deploy.sh
+++ b/scripts/pull_and_deploy.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+#pull latest changes, build app and deploy on port $1
+
+if [ $# -eq 1 ]; then
+        PORT_NUMBER=$1
+
+        #pull latest changes of this branch
+        git pull
+        #build project on this branch
+        mvn compile
+        #deploy to port $1
+        nohup mvn exec:java -D"exec.mainClass"="com.group10.CI.ContinuousIntegrationServer" -Dexec.args="$1" &> /dev/null &
+
+else
+        echo "Argument missing: You need to provide port to runt ngrok server"
+fi

--- a/scripts/pull_and_redeploy.sh
+++ b/scripts/pull_and_redeploy.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+#pull latest changes, build app and redeploy on port $1
+
+if [ $# -eq 1 ]; then
+        PORT_NUMBER=$1
+
+        # Kill the working app,
+        SERVER_PID=$(pgrep -f Dexec.args="$1")
+        kill $SERVER_PID
+
+        #pull latest changes of this branch
+        git pull
+
+        #build project on this branch
+        mvn compile
+
+        #deploy to port $1
+        nohup mvn exec:java -D"exec.mainClass"="com.group10.CI.ContinuousIntegrationServer" -Dexec.args="$1" &> /dev/null &
+
+else
+        echo "Argument missing: You need to provide port to runt ngrok server"
+fi

--- a/scripts/redeploy.sh
+++ b/scripts/redeploy.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+#redeploy the app on port $1
+
+if [ $# -eq 1 ]; then
+        PORT_NUMBER=$1
+
+        # Kill the working app,
+        SERVER_PID=$(pgrep -f Dexec.args="$1")
+        kill $SERVER_PID
+
+        # compile the app from current branch
+        mvn compile
+
+        # deploy app to the port $1
+        nohup mvn exec:java -D"exec.mainClass"="com.group10.CI.ContinuousIntegrationServer" -Dexec.args="$1" &> /dev/null &
+
+else
+        echo "Argument missing: You need to provide port to runt ngrok server"
+fi


### PR DESCRIPTION
Fixes #23.

This PR is absolutely dependent on the PR #21. Please merge that pull request/review it before merging/reviewing this one.

IMPORTANT!: These scripts are meant to be run on the remote server. They spawn processes that work in the background. If you use them in your computer, you need to manually kill those processes afterwards. 

I recommend not executing these scripts on your personal machine.

I am open to suggestions on how to find the PID of the running process when we are redeploying the app. You can find how I do it in redeploy scripts. If you have a better idea, please share it with me. 
Until then I recommend manually killing the working app and deploying with script to prevent redeploy scripts to kill unintended processes.

This PR introduces 4 new scripts

- deploy.sh
  - Deploy the app in current git branch to the port $1
- redeploy.sh
  - Redeploy the app on port $1
- pull_and_deploy.sh
  - Pull latest changes, build app and deploy on port $1
- pull_and_redeploy.sh
  - Pull latest changes, build app and redeploy on port $1