### PR TITLE
Serving history via HTML

### DIFF
--- a/src/main/java/com/group10/CI/ContinuousIntegrationServer.java
+++ b/src/main/java/com/group10/CI/ContinuousIntegrationServer.java
@@ -37,9 +37,7 @@ public class ContinuousIntegrationServer extends AbstractHandler {
 
         System.out.println(target);
 
-
-        PrintWriter out = response.getWriter();
-       // out.println("Job starting.");
+        // out.println("Job starting.");
         Build build;
         // if server receives a webhook
         if (request.getMethod() == "POST") {
@@ -50,12 +48,16 @@ public class ContinuousIntegrationServer extends AbstractHandler {
             try {
 
                 build = handlePostRequest(request);
-                if(build.equals(null)) return;
+                if (build.equals(null))
+                    return;
 
-                /*TODO: Add information to history object*/
-                /*String html = "Commit sha: " + build.getPrId() + " | Build status: " + build.getBuildStatus() + " | Test status: " + build.getTestStatus();
-                System.out.println("HTML: " + html);
-                out.println(html);*/
+                /* TODO: Add information to history object */
+                /*
+                 * String html = "Commit sha: " + build.getPrId() + " | Build status: " +
+                 * build.getBuildStatus() + " | Test status: " + build.getTestStatus();
+                 * System.out.println("HTML: " + html);
+                 * out.println(html);
+                 */
 
             } catch (InterruptedException e) {
                 System.out.println("Error when handling the post request: " + e.getMessage());
@@ -103,19 +105,21 @@ public class ContinuousIntegrationServer extends AbstractHandler {
     private Build handlePostRequest(HttpServletRequest request) throws IOException, InterruptedException {
         JSONObject body = getBody(request);
 
-        if(body.equals(new JSONObject("{}"))) return null;
-        
+        if (body.equals(new JSONObject("{}")))
+            return null;
+
         // Fetch the relevant info from POST request
         String branch = body.getJSONObject("pull_request").getJSONObject("head").getString("ref");
         String repoUrl = body.getJSONObject("repository").getString("html_url");
         String commitSha = body.getJSONObject("pull_request").getJSONObject("head").getString("sha");
-        String gitUrl = body.getJSONObject("pull_request").getJSONObject("head").getJSONObject("repo").getString("full_name");
+        String gitUrl = body.getJSONObject("pull_request").getJSONObject("head").getJSONObject("repo")
+                .getString("full_name");
 
-        System.out.println("Handle post request: \nCommit Sha: " + commitSha + " | Branch: "  + branch + " | Git url: " + gitUrl + " | Temp dir: " + repoUrl);
-
+        System.out.println("Handle post request: \nCommit Sha: " + commitSha + " | Branch: " + branch + " | Git url: "
+                + gitUrl + " | Temp dir: " + repoUrl);
 
         // clone
-        //System.out.println("Cloning branch " + branch + " from url " + gitUrl);
+        // System.out.println("Cloning branch " + branch + " from url " + gitUrl);
         GitHandler git = new GitHandler();
         boolean hasCloned = git.cloneRepo(repoUrl, branch);
         if (!hasCloned)
@@ -165,7 +169,7 @@ public class ContinuousIntegrationServer extends AbstractHandler {
         try {
             BufferedReader br = request.getReader();
             String line;
-            while ((line = br.readLine()) != null){
+            while ((line = br.readLine()) != null) {
                 stringBuilder.append(line);
             }
             return new JSONObject(stringBuilder.toString());

--- a/src/main/java/com/group10/CI/ContinuousIntegrationServer.java
+++ b/src/main/java/com/group10/CI/ContinuousIntegrationServer.java
@@ -1,10 +1,14 @@
 package com.group10.CI;
+
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import javax.servlet.ServletException;
 
 import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileNotFoundException;
 import java.io.IOException;
+import java.io.PrintWriter;
 import java.util.Arrays;
 
 import org.eclipse.jetty.server.Server;
@@ -14,20 +18,20 @@ import org.eclipse.jetty.server.handler.AbstractHandler;
 import org.json.*;
 
 /**
- Skeleton of a ContinuousIntegrationServer which acts as webhook
- See the Jetty documentation for API documentation of those classes.
+ * Skeleton of a ContinuousIntegrationServer which acts as webhook
+ * See the Jetty documentation for API documentation of those classes.
  */
-public class ContinuousIntegrationServer extends AbstractHandler
-{
+public class ContinuousIntegrationServer extends AbstractHandler {
     public void handle(String target,
-                       Request baseRequest,
-                       HttpServletRequest request,
-                       HttpServletResponse response)
-            throws IOException, ServletException
-    {
+            Request baseRequest,
+            HttpServletRequest request,
+            HttpServletResponse response)
+            throws IOException, ServletException {
         response.setContentType("text/html;charset=utf-8");
         response.setStatus(HttpServletResponse.SC_OK);
         baseRequest.setHandled(true);
+
+        PrintWriter out = response.getWriter();
 
         System.out.println(target);
 
@@ -36,9 +40,11 @@ public class ContinuousIntegrationServer extends AbstractHandler
             try {
                 Build build = handlePostRequest(request);
                 response.getWriter().println(build.toString());
-                if(build.equals(null)) return;
+                if (build.equals(null))
+                    return;
 
-                String html = "Commit sha: " + build.getPrId() + " | Build status: " + build.getBuildStatus() + " | Test status: " + build.getTestStatus() + "<p>";
+                String html = "Commit sha: " + build.getPrId() + " | Build status: " + build.getBuildStatus()
+                        + " | Test status: " + build.getTestStatus() + "<p>";
                 response.getWriter().println("CI job done");
                 response.getWriter().println(html);
                 response.getWriter().flush();
@@ -46,14 +52,50 @@ public class ContinuousIntegrationServer extends AbstractHandler
                 System.out.println("Error when handling the post request: " + e.getMessage());
                 return;
             }
+        } else if (request.getMethod() == "GET") {
+            String resp = handleGetRequest(request, target);
+
+            out.write(resp);
         }
 
+        out.flush();
 
+    }
+
+    private String handleGetRequest(HttpServletRequest request, String target) {
+        // Trim following and preceding slashes of the target uri
+        target = target.replaceFirst("^/", "").replace("/$", "");
+
+        String[] targetParts = target.split("/");
+        // Match which function we want to reach
+        if (target.equals("history")) {
+            // list items in history directory to a html document
+            File historyDir = new File("history");
+            return HtmlFormater.formatHtmlHrefList("All repos", historyDir.list(), "history/");
+        } else if (target.matches("history/[A-Za-z0-9_.-]+")) {
+            // list items in repo history directory to a html document
+            File dir = new File(target);
+            return HtmlFormater.formatHtmlHrefList("Build history for " + targetParts[1], dir.list(),
+                    targetParts[1] + "/");
+        } else if (target.matches("history/[A-Za-z0-9_.-]+/[A-Za-z0-9]+")) {
+            // fetch items from file and place in a html document, if they exist
+            HistoryHandler hh = new HistoryHandler(targetParts[1]);
+            try {
+                return HtmlFormater.formatHtml("Build " + targetParts[2], hh.getHistory(targetParts[2]));
+            } catch (FileNotFoundException e) {
+                // TODO: handle exception
+                return HtmlFormater.formatHtml("No history found", "There is no history with this ID in this repo");
+            }
+        } else {
+            // if nothing is matched it doesn't exist
+            return HtmlFormater.formatHtml("404 Not Found", "No content here");
+        }
     }
 
     private Build handlePostRequest(HttpServletRequest request) throws IOException, InterruptedException {
         JSONObject body = getBody(request);
-        if(body.equals(null)) return null;
+        if (body.equals(null))
+            return null;
         System.out.println("JSON BODY:\n" + body);
 
         String[] ref = body.getString("ref").split("/");
@@ -70,15 +112,18 @@ public class ContinuousIntegrationServer extends AbstractHandler
         System.out.println("Cloning branch: " + branch + " from url: " + repoUrl);
         GitHandler git = new GitHandler();
         boolean hasCloned = git.cloneRepo(repoUrl, branch);
-        if(!hasCloned) return null;  //unable to clone
+        if (!hasCloned)
+            return null; // unable to clone
 
         // compile
         System.out.println("Compiling project.");
         CompileHandler compileHandler = new CompileHandler(commitSha, repoUrl);
         compileHandler.compile();
 
-        // if unable to execute compilation command, we do not want to send a notification
-        if(compileHandler.getStatus() == Status.ERROR) return null;
+        // if unable to execute compilation command, we do not want to send a
+        // notification
+        if (compileHandler.getStatus() == Status.ERROR)
+            return null;
 
         build.setBuildStatus(compileHandler.getStatus());
 
@@ -88,24 +133,27 @@ public class ContinuousIntegrationServer extends AbstractHandler
         testHandler.test();
 
         // if unable to execute test command, we do not want to send a notification
-        if(testHandler.getStatus() == Status.ERROR) return null;
+        if (testHandler.getStatus() == Status.ERROR)
+            return null;
 
         build.setTestStatus(testHandler.getStatus());
         System.out.println("Build and testing complete.");
 
         notifier.notifyGitHub(build);
 
-        if(!notifier.getSuccessfulDelivery()) System.out.println("Unable to notify Github.");
+        if (!notifier.getSuccessfulDelivery())
+            System.out.println("Unable to notify Github.");
         return build;
     }
 
-    private JSONObject getBody(HttpServletRequest request){
+    private JSONObject getBody(HttpServletRequest request) {
         StringBuilder stringBuilder = new StringBuilder();
 
         try {
             BufferedReader br = request.getReader();
             String line;
-            while ((line = br.readLine()) != null) stringBuilder.append(line);
+            while ((line = br.readLine()) != null)
+                stringBuilder.append(line);
             return new JSONObject(stringBuilder);
         } catch (IOException e) {
             System.out.println("ERROR");
@@ -118,9 +166,10 @@ public class ContinuousIntegrationServer extends AbstractHandler
     // used to start the CI server in command line
     // takes 0 or 1 arguments.
     // usage: java ContnuousIntegrationServer.java [PORT_NUMBER]
-    // mvn usage: mvn exec:java -D"exec.mainClass"="com.group10.CI.ContinuousIntegrationServer" -Dexec.args="<PORT_NUMBER>"
-    public static void main(String[] args) throws Exception
-    {
+    // mvn usage: mvn exec:java
+    // -D"exec.mainClass"="com.group10.CI.ContinuousIntegrationServer"
+    // -Dexec.args="<PORT_NUMBER>"
+    public static void main(String[] args) throws Exception {
         int default_port_number = 8080;
         int port_number;
 

--- a/src/main/java/com/group10/CI/HistoryHandler.java
+++ b/src/main/java/com/group10/CI/HistoryHandler.java
@@ -47,7 +47,7 @@ public class HistoryHandler {
      * @throws IOException When there is an error writing to the file
      */
     public void saveHistory(String commitId, String message) throws IOException {
-        FileWriter historyFileWriter = new FileWriter(repoHistoryFolder + commitId + ".txt");
+        FileWriter historyFileWriter = new FileWriter(repoHistoryFolder + commitId);
 
         historyFileWriter.write(message);
 
@@ -63,7 +63,7 @@ public class HistoryHandler {
      * @throws FileNotFoundException When there is no build info file
      */
     public String getHistory(String commitId) throws FileNotFoundException {
-        File historyFile = new File(repoHistoryFolder + commitId + ".txt");
+        File historyFile = new File(repoHistoryFolder + commitId);
 
         Scanner s = new Scanner(historyFile);
         StringBuilder sb = new StringBuilder();

--- a/src/main/java/com/group10/CI/HtmlFormater.java
+++ b/src/main/java/com/group10/CI/HtmlFormater.java
@@ -1,0 +1,39 @@
+package com.group10.CI;
+
+/**
+ * Class for formatting HTML with a HTML boilerplate
+ */
+public class HtmlFormater {
+
+    protected static String htmlFormat = "<!DOCTYPE html><html lang=\"en\"><head><meta charset=\"UTF-8\"><meta name=\"viewport\" content=\"width=device-width, initial-scale=1.0\"><title>%s</title></head><body>%s</body></html>";
+
+    /**
+     * Formats a plain HTML site with the header and content provided
+     * 
+     * @param header  The sites header
+     * @param content The displayed info on the site, can be in HTML or plain text
+     * @return A formatted html site
+     */
+    public static String formatHtml(String header, String content) {
+        return String.format(htmlFormat, header, content);
+    }
+
+    /**
+     * Formats a plain HTML site with the header and a unordered list
+     * 
+     * @param header The sites header
+     * @param list   A list that will be displayed on the site
+     * @return A formatted html site
+     */
+    public static String formatHtmlHrefList(String header, String[] list, String prefix) {
+        StringBuilder content = new StringBuilder();
+        content.append("<ul>");
+        for (String item : list) {
+            content.append(String.format("<li><a href=\"%s%s\">%s</a></li>", prefix, item, item));
+        }
+        content.append("</ul>");
+
+        return formatHtml(header, content.toString());
+    }
+
+}

--- a/src/test/java/com/group10/CI/HistoryHandlerTest.java
+++ b/src/test/java/com/group10/CI/HistoryHandlerTest.java
@@ -50,7 +50,7 @@ public class HistoryHandlerTest {
     public void resetTestFolder() throws IOException {
         FileUtils.cleanDirectory(new File("history/testing"));
 
-        FileWriter fw = new FileWriter(new File("history/testing/fileExists.txt"));
+        FileWriter fw = new FileWriter(new File("history/testing/fileExists"));
         fw.write(testMessage);
         fw.close();
     }
@@ -77,7 +77,7 @@ public class HistoryHandlerTest {
     public void saveHistoryTestFileDoesNotExist() {
         try {
             hh.saveHistory(testCommitId, testMessage);
-            File newHistory = new File("history/testing/" + testCommitId + ".txt");
+            File newHistory = new File("history/testing/" + testCommitId);
             assertEquals(false, newHistory.createNewFile(), "The expected written file shouldn't be new");
         } catch (IOException e) {
             fail();
@@ -92,7 +92,7 @@ public class HistoryHandlerTest {
     @Test
     @DisplayName("Tests saving info to already existing file")
     public void saveHistoryTestFileAlreadyExists() {
-        File existingHistory = new File("history/testing/testExists.txt");
+        File existingHistory = new File("history/testing/testExists");
         long timeBeforeModification = existingHistory.lastModified();
         try {
             hh.saveHistory("testExists", testMessage);


### PR DESCRIPTION
In a user sends a GET request to the server, they should be able to navigate to all build infos.

The possible GET requests are the following:

- `/history`: This displays all the repos which the CI server has compiled and tested
- `/history/REPO-NAME`: By specifying the repository name, the server can display all builds that have been performed on that repo. Possible REPO-NAME's are displayed in `history`
- `/history/REPO-NAME/COMMIT-ID`: Here you have detailed information about a specific build with commit identifier COMMIT-ID. The possible COMMIT-ID's are displayed the lower url  `/history/REPO-NAME`

Closes #14