### PR TITLE
Added link to the history for the GitHub message and pending state, feat #51

### DIFF
--- a/src/main/java/com/group10/CI/NotificationHandler.java
+++ b/src/main/java/com/group10/CI/NotificationHandler.java
@@ -48,7 +48,13 @@ public class NotificationHandler {
         String prId = build.getPrId();
         String status = build.getBuildStatus().toString().toLowerCase(); //Not sure if we only should send the general status.
         String postURL = "https://api.github.com/repos/" + repo  + "/statuses/" + prId;
-        String postBody = "{\"state\":\"" + status + "\",\"target_url\":\"http://localhost:8080/CI/build.html?prId=" + prId + "\",\"description\":\"Build status\",\"context\":\"CI\"}";
+        String postBody;
+        if(status == "pending"){
+            postBody = "{\"state\":\"" + status + "\",\"description\":\"Build status pending\",\"context\":\"Custom CI Server \"}";
+        }
+        else {
+            postBody = "{\"state\":\"" + status + "\",\"target_url\":\"http://0cc9-3-16-36-86.ngrok.io/history/" + repo + "/" + prId + "\",\"description\":\"Build status " + status + " \",\"context\":\"Custom CI Server\"}";
+        }
 
         //Sending the post request
         try{

--- a/src/main/java/com/group10/CI/NotificationHandler.java
+++ b/src/main/java/com/group10/CI/NotificationHandler.java
@@ -45,6 +45,8 @@ public class NotificationHandler {
      */
     public void notifyGitHub(Build build){
         String repo = build.getRepo(); // Ex. ludwigjo/SE-Gorup10-CI
+        //The name witout the user before /
+        String repoName = repo.substring(repo.indexOf("/") + 1);
         String prId = build.getPrId();
         String status = build.getBuildStatus().toString().toLowerCase(); //Not sure if we only should send the general status.
         String postURL = "https://api.github.com/repos/" + repo  + "/statuses/" + prId;
@@ -53,7 +55,7 @@ public class NotificationHandler {
             postBody = "{\"state\":\"" + status + "\",\"description\":\"Build status pending\",\"context\":\"Custom CI Server \"}";
         }
         else {
-            postBody = "{\"state\":\"" + status + "\",\"target_url\":\"http://0cc9-3-16-36-86.ngrok.io/history/" + repo + "/" + prId + "\",\"description\":\"Build status " + status + " \",\"context\":\"Custom CI Server\"}";
+            postBody = "{\"state\":\"" + status + "\",\"target_url\":\"http://0cc9-3-16-36-86.ngrok.io/history/" + repoName + "/" + prId + "\",\"description\":\"Build status " + status + " \",\"context\":\"Custom CI Server\"}";
         }
 
         //System.out.println("REPO: " + repo + " PR ID: " + prId + " POST URL: "+ postURL + " POST BODY: " + postBody);

--- a/src/test/java/com/group10/CI/NotificationHandlerTest.java
+++ b/src/test/java/com/group10/CI/NotificationHandlerTest.java
@@ -36,4 +36,17 @@ public class NotificationHandlerTest {
         nh.notifyGitHub(build);
         assertEquals(false, nh.getSuccessfulDelivery());
     }
+
+    /**
+     * Testing that the pending status is set correctly to github.
+     * We should receive a 201 code when the notification is sent to github.
+     */
+    @Test
+    @DisplayName("Positive test for pending status")
+    public void testPendingStatus() {
+        Build build = new Build("78682ea6f5917499797e1a78827a2e41556b44c8", "hello@email.com", Status.PENDING, Status.FAILURE, "ludwigjo/SE-Gorup10-CI");
+        NotificationHandler nh = new NotificationHandler();
+        nh.notifyGitHub(build);
+        assertEquals(true, nh.getSuccessfulDelivery());
+    }
 }


### PR DESCRIPTION
This PR adds the link to the history page for the current commit in the message sent to GitHub. It also adds the possibility to deliver a pending message to GitHub while it's waiting. 

Closes #51