### PR TITLE
Implemented saving of Build info, feat #60

### DIFF
--- a/src/main/java/com/group10/CI/Build.java
+++ b/src/main/java/com/group10/CI/Build.java
@@ -4,19 +4,22 @@ package com.group10.CI;
  * Build class taking care of the build information.
  */
 public class Build {
-    
+
     private String prId;
     private String email;
     private Status buildStatus;
+    private String buildInfo;
     private Status testStatus;
-    private String repo;    //The repo name. Ex. ludwigjo/SE-Group10-CI
+    private String testInfo;
+    private String repo; // The repo name. Ex. ludwigjo/SE-Group10-CI
 
     /**
      * Constructor for Build class.
-     * @param prId the prId of the build. Also called SHA in the gitHub API.
-     * @param email the email of the user who initiated the build.
+     * 
+     * @param prId        the prId of the build. Also called SHA in the gitHub API.
+     * @param email       the email of the user who initiated the build.
      * @param buildStatus the status of the build.
-     * @param testStatus the status of the tests.
+     * @param testStatus  the status of the tests.
      */
     public Build(String prId, String email, Status buildStatus, Status testStatus, String repo) {
         this.prId = prId;
@@ -25,11 +28,14 @@ public class Build {
         this.testStatus = testStatus;
         this.repo = repo;
     }
-    //Default constructor
-    public Build() {}
+
+    // Default constructor
+    public Build() {
+    }
 
     /**
      * Get method for prId.
+     * 
      * @return prId the id for a pull request. Also called SHA in the gitHub API.
      */
     public String getPrId() {
@@ -38,6 +44,7 @@ public class Build {
 
     /**
      * Get method for email.
+     * 
      * @return email the email of the user.
      */
     public String getEmail() {
@@ -46,6 +53,7 @@ public class Build {
 
     /**
      * Get method for buildStatus.
+     * 
      * @return buildStatus the status of the build.
      */
     public Status getBuildStatus() {
@@ -53,7 +61,17 @@ public class Build {
     }
 
     /**
+     * Get method for buildInfo.
+     * 
+     * @return buildInfo the standard output of the build process.
+     */
+    public String getBuildInfo() {
+        return buildInfo;
+    }
+
+    /**
      * Get method for testStatus.
+     * 
      * @return testStatus the status of the tests.
      */
     public Status getTestStatus() {
@@ -61,7 +79,17 @@ public class Build {
     }
 
     /**
+     * Get method for testInfo.
+     * 
+     * @return testInfo the standard output for test process.
+     */
+    public String getTestInfo() {
+        return testInfo;
+    }
+
+    /**
      * Get method for repo.
+     * 
      * @return repo the repo name. Ex. ludwigjo/SE-Group10-CI
      */
     public String getRepo() {
@@ -70,12 +98,16 @@ public class Build {
 
     /**
      * Get method for the build
-     * @return  this build object
-     * */
-    public Build getBuild(){ return this; }
+     * 
+     * @return this build object
+     */
+    public Build getBuild() {
+        return this;
+    }
 
     /**
      * Set method for prId.
+     * 
      * @param prId the id for a pull request. Also called SHA in the gitHub API.
      */
     public void setPrId(String prId) {
@@ -84,6 +116,7 @@ public class Build {
 
     /**
      * Set method for email.
+     * 
      * @param email the email of the user.
      */
     public void setEmail(String email) {
@@ -92,6 +125,7 @@ public class Build {
 
     /**
      * Set method for buildStatus.
+     * 
      * @param buildStatus the status of the build.
      */
     public void setBuildStatus(Status buildStatus) {
@@ -99,7 +133,17 @@ public class Build {
     }
 
     /**
+     * Set method for buildInfo.
+     * 
+     * @param buildInfo the standard output of the build process.
+     */
+    public void setBuildInfo(String buildInfo) {
+        this.buildInfo = buildInfo;
+    }
+
+    /**
      * Set method for testStatus.
+     * 
      * @param testStatus the status of the tests.
      */
     public void setTestStatus(Status testStatus) {
@@ -107,18 +151,30 @@ public class Build {
     }
 
     /**
+     * Set method for testInfo.
+     * 
+     * @param testInfo the standard output of the test process.
+     */
+    public void setTestInfo(String testInfo) {
+        this.testInfo = testInfo;
+    }
+
+    /**
      * Set method for repo.
+     * 
      * @param repo the repo name. Ex. ludwigjo/SE-Group10-CI
      */
     public void setRepo(String repo) {
         this.repo = repo;
     }
 
-    public String toString(){
+    public String toString() {
         String s = "";
         s += "Commit SHA: " + this.getPrId();
         s += "\nBuild Status: " + this.getBuildStatus();
-        s += "\nTest Status" + this.getTestStatus();
+        s += "\nBuild info: " + this.getBuildInfo();
+        s += "\nTest Status: " + this.getTestStatus();
+        s += "\nTest info: " + this.getTestInfo();
         return s;
     }
 }

--- a/src/main/java/com/group10/CI/ContinuousIntegrationServer.java
+++ b/src/main/java/com/group10/CI/ContinuousIntegrationServer.java
@@ -119,19 +119,18 @@ public class ContinuousIntegrationServer extends AbstractHandler {
 
         System.out.println("Handle post request: \nCommit Sha: " + commitSha + " | Branch: " + branch + " | Git url: "
                 + gitUrl + " | Temp dir: " + repoUrl);
-        
+
         // instantiate new build object and notification handler
         Build build = new Build(commitSha, "", Status.PENDING, Status.PENDING, gitUrl);
         NotificationHandler notifier = new NotificationHandler();
         notifier.notifyGitHub(build);
-        
+
         // clone
         // System.out.println("Cloning branch " + branch + " from url " + gitUrl);
         GitHandler git = new GitHandler();
         boolean hasCloned = git.cloneRepo(repoUrl, branch);
         if (!hasCloned)
             return null; // unable to clone
-
 
         // compile
         System.out.println("Compiling project.");
@@ -144,6 +143,7 @@ public class ContinuousIntegrationServer extends AbstractHandler {
             return null;
 
         build.setBuildStatus(compileHandler.getStatus());
+        build.setBuildInfo(compileHandler.getInformation());
 
         // test
         System.out.println("Testing project.");
@@ -158,6 +158,7 @@ public class ContinuousIntegrationServer extends AbstractHandler {
             return null;
 
         build.setTestStatus(testHandler.getStatus());
+        build.setTestInfo(testHandler.getInformation());
         System.out.println("Build and testing complete.");
 
         notifier.notifyGitHub(build);


### PR DESCRIPTION
When POSTing to the server it should now save the standard output of the `mvn compile` and `mvn test` commands into the Build object created.

Closes #60.